### PR TITLE
Add “Income (€)” , “Carbon Offset (ton)” and „ Create  Time“ sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ A custom Home Assistant integration to retrieve real-time data from the Envertec
 | `UnitEMonth`      | Monthly Energy     | kWh   | Energy produced this month                     |
 | `UnitEYear`       | Yearly Energy      | kWh   | Energy produced this year                      |
 | `UnitETotal`      | Total Energy       | kWh   | Total energy since commissioning              |
+| "StrIncome"	      | Income             | €      | Refund in € if set in APP 			           |
+| "StrCO2           | Carbon Offset      | ton    | CO² offset                                    |
+| "CreateTime"      |  Start Date        |  None  | Date you setup your Envertec Powerstation |
 
+ 
 <img width="300" height="500" alt="grafik" src="https://github.com/user-attachments/assets/e4402d2e-155c-425c-bb9e-d1bfa3d65c27" />
 
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A custom Home Assistant integration to retrieve real-time data from the Envertec
 | "CreateTime"      |  Start Date        |  None  | Date you setup your Envertec Powerstation |
 
  
-<img width="300" height="500" alt="grafik" src="https://github.com/user-attachments/assets/e4402d2e-155c-425c-bb9e-d1bfa3d65c27" />
+<img width="339" height="724" alt="Bildschirmfoto vom 2025-11-03 23-23-24" src="https://github.com/user-attachments/assets/1715cfcf-a921-4880-ae17-04f783556493" />
 
 
 ## Credits

--- a/custom_components/envertech_solar/sensor.py
+++ b/custom_components/envertech_solar/sensor.py
@@ -61,6 +61,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         ("UnitETotal", "Total Energy", "kWh", "mdi:solar-power"),
         ("InvModel1", "Inverter Model", None, "mdi:solar-power"),
         ("StrPeakPower", "All-Time Peak Power", None, "mdi:flash"),  # eindeutiger Name
+        ("StrIncome", "Income", "€", "mdi:cash"),
+        ("StrCO2", "Carbon Offset", "ton", "mdi:molecule-co2"),
+	    ("CreateTime",  "Start Date", None, "mdi:view-day"),
     ]
 
     entities = [
@@ -125,14 +128,23 @@ class EnvertechSensor(SensorEntity):
 
         if isinstance(val, str):
             try:
-                cleaned = val.replace(",", ".").replace("kWh", "").replace("W", "").replace("kW", "").strip()
+                # Entferne unerwünschte Zeichen
+                cleaned = (
+                    val.replace(",", ".")
+                       .replace("kWh", "")
+                       .replace("W", "")
+                       .replace("kW", "")
+                       .replace("€", "")
+                       .replace("ton", "")
+                       .strip()
+                )
                 number = float(cleaned)
                 if "kW" in val and self._attr_native_unit_of_measurement == "W":
                     number *= 1000
                 return number
             except Exception as e:
                 _LOGGER.warning("Could not convert value '%s' for sensor '%s': %s", val, self.sensor_key, e)
-                return None
+                return val  # <--- vorher: return None, jetzt geben wir den String zurück, falls nicht konvertierbar
 
         return val
 
@@ -245,3 +257,4 @@ class EnvertechPeakTodaySensor(RestoreEntity, SensorEntity):
         self.async_on_remove(
             self.coordinator.async_add_listener(self.async_write_ha_state)
         )
+


### PR DESCRIPTION
This update adds three new sensors to the Envertech Solar integration:
    • sensor.income → current total income in €
    • sensor.carbon_offset → total CO₂ offset in tons
    • sensor.start_date → date of setup as date
All values are available in the Envertech Cloud API under the fields StrIncome , StrCO2 and CreateTime. Changes
    • Updated sensor.py to include the additional sensor entities (EnvertechIncomeSensor, EnvertechCarbonOffsetSensor and EnvertecCreateTimeSensor)
    • Each sensor uses the existing API data structure and follows the same update cycle as the other sensors
Tested Environment
    • Home Assistant 2025.11
    • Working with Envertech Cloud login
    • The three new sensors show correct values and update as expected



Credits
Enhancement by @manfredkupper